### PR TITLE
correct the varible name 'mesh' in line 58

### DIFF
--- a/data/extract_sdf.py
+++ b/data/extract_sdf.py
@@ -55,11 +55,12 @@ def main(cfg):
             # Convert to watertight mesh
             mesh_original = utils_mesh._as_mesh(trimesh.load(obj_path))
             
-            if not mesh.is_watertight:
+            if not mesh_original.is_watertight:
                 verts, faces = pcu.make_mesh_watertight(mesh_original.vertices, mesh_original.faces, 50000)
                 mesh_original = trimesh.Trimesh(vertices=verts, faces=faces)
 
-        except:
+        except Exception as e:
+            print(e)
             continue
 
         # In Shapenet, the front is the -Z axis with +Y still being the up axis. Rotate objects to align with the canonical axis. 


### PR DESCRIPTION
The variable ‘mesh’ in line 58 should be corrected to mesh_original.

Additionally, because this error occurs in a try-except block, the terminal doesn't report the error message when this script runs, but the sample_dict is empty. In order to quickly identify the cause of the error, I modified the code of except-block to print the error message.